### PR TITLE
edit README with APP-NAME in cf push command for new users

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ OK
 Now push the application: 
 
 ~~~
-$ cf push --random-route
+$ cf push APP-NAME --random-route
 Using manifest file manifest.yml
 
 Updating app rails-sample


### PR DESCRIPTION
Editing this README for clarity for newbie users. The cf CLI displays an error if you omit the app's name after `cf push`.
