### PR TITLE
Update app to work on CFv238/Diego v0.1476.0/Buildpack:ruby 1.6.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sqlite3', '1.3.4'
 gem "pg", "~> 0.15.1"
 gem "cf-autoconfig", "~> 0.2.1"
 gem 'rails_12factor', group: :production
-ruby '2.0.0'
+ruby '2.1.9'
 
 group :development do
   gem 'rspec-rails', '2.6.1'

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: rails-sample
+  random-route: true
   memory: 256M
   instances: 1
   path: .


### PR DESCRIPTION
The current run.pivotal.io getting started docs reference this app, and don't work.

![screen shot 2016-07-12 at 15 04 35](https://cloud.githubusercontent.com/assets/227505/16769794/11466a30-4842-11e6-92fa-e28271176a1f.png)

This PR contains 2 fixes:

0.  It assigns a random route to prevent conflicts
0.  It bumps the required ruby version to one supported by the current ruby build pack.