### PR TITLE
Move rspec-rails in Gemfile to fix warning from Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,13 +10,11 @@ gem 'rails_12factor', group: :production
 ruby '2.1.9'
 
 group :development do
-  gem 'rspec-rails', '2.6.1'
   gem 'annotate', '2.4.0'
   gem 'faker', '0.3.1'
 end
 
 group :test do
-  gem 'rspec-rails', '2.6.1'
   gem 'webrat', '0.7.1'
   gem 'spork', '0.9.0.rc8'
   gem 'factory_girl_rails', '1.0'
@@ -24,4 +22,8 @@ group :test do
   # gem 'autotest-rails-pure', '4.1.2'
   # gem 'autotest-fsevent', '0.2.4'
   # gem 'autotest-growl', '0.2.9'
+end
+
+group :development, :test do
+  gem 'rspec-rails', '2.6.1'
 end


### PR DESCRIPTION
Fixes the following warning:

```
$ bundle install
Your Gemfile lists the gem rspec-rails (= 2.6.1) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```